### PR TITLE
[BUGFIX] Set correct return types

### DIFF
--- a/Classes/Processor/VideoProcessor.php
+++ b/Classes/Processor/VideoProcessor.php
@@ -23,8 +23,7 @@ class VideoProcessor
     /**
      *
      * @param \TYPO3\CMS\Core\Resource\FileInterface $file
-     * @return array
-     * @SuppressWarnings(PHPMD.Superglobals)
+     * @return array|null
      */
     public function renderVideo(FileInterface $file): ?array
     {
@@ -46,7 +45,7 @@ class VideoProcessor
 
     /**
      * @param FileInterface $file
-     * @return string
+     * @return string|null
      */
     protected function getPublicVideoUri(FileInterface $file): ?string
     {


### PR DESCRIPTION
The return type null was missing and produce an exception in VideoProcessor class.