### PR TITLE
[FEATURE] Add new event in ImageProcessor

### DIFF
--- a/Classes/Processor/Event/ImageProcessorManipulateImgResourceResultEvent.php
+++ b/Classes/Processor/Event/ImageProcessorManipulateImgResourceResultEvent.php
@@ -10,9 +10,12 @@ class ImageProcessorManipulateImgResourceResultEvent
 {
     protected array $renderedResult;
 
-    public function __construct(array $renderedResult)
+    protected array $imageConfiguration;
+
+    public function __construct(array $renderedResult, array $imageConfiguration)
     {
         $this->renderedResult = $renderedResult;
+        $this->imageConfiguration = $imageConfiguration;
     }
 
     public function getRenderedResult(): array
@@ -23,5 +26,10 @@ class ImageProcessorManipulateImgResourceResultEvent
     public function setRenderedResult(array $renderedResult): void
     {
         $this->renderedResult = $renderedResult;
+    }
+
+    public function getImageConfiguration(): array
+    {
+        return $this->imageConfiguration;
     }
 }

--- a/Classes/Processor/Event/ImageProcessorManipulateImgResourceResultEvent.php
+++ b/Classes/Processor/Event/ImageProcessorManipulateImgResourceResultEvent.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+namespace PrototypeIntegration\PrototypeIntegration\Processor\Event;
+
+/**
+ * Class ImageProcessorManipulateImgResourceResultEvent
+ */
+class ImageProcessorManipulateImgResourceResultEvent
+{
+    protected array $renderedResult;
+
+    public function __construct(array $renderedResult)
+    {
+        $this->renderedResult = $renderedResult;
+    }
+
+    public function getRenderedResult(): array
+    {
+        return $this->renderedResult;
+    }
+
+    public function setRenderedResult(array $renderedResult): void
+    {
+        $this->renderedResult = $renderedResult;
+    }
+}

--- a/Classes/Processor/Event/ImageProcessorManipulateImgResourceResultEvent.php
+++ b/Classes/Processor/Event/ImageProcessorManipulateImgResourceResultEvent.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 namespace PrototypeIntegration\PrototypeIntegration\Processor\Event;
 

--- a/Classes/Processor/ImageProcessor.php
+++ b/Classes/Processor/ImageProcessor.php
@@ -32,7 +32,7 @@ class ImageProcessor
     public function renderImage(FileInterface $file, array $conf = []): array
     {
         $defaultImageResource = $this->contentObject->getImgResource($file, $conf);
-        $this->runImageResourceManipulationEvent($defaultImageResource);
+        $this->runImageResourceManipulationEvent($defaultImageResource, $conf);
 
         $retinaImageResource = self::renderRetinaImage($file, $conf);
 
@@ -60,7 +60,7 @@ class ImageProcessor
     {
         $retinaConfiguration = $this->getImageConfigurationForRetina($configuration);
         $defaultImageResource = $this->contentObject->getImgResource($file, $retinaConfiguration);
-        $this->runImageResourceManipulationEvent($defaultImageResource);
+        $this->runImageResourceManipulationEvent($defaultImageResource, $retinaConfiguration);
 
         return $defaultImageResource[3];
     }
@@ -126,9 +126,9 @@ class ImageProcessor
         return $retinaConfig;
     }
 
-    private function runImageResourceManipulationEvent(array &$defaultImageResource): void
+    private function runImageResourceManipulationEvent(array &$defaultImageResource, array $imageConfiguration = []): void
     {
-        $event = new Event\ImageProcessorManipulateImgResourceResultEvent($defaultImageResource);
+        $event = new Event\ImageProcessorManipulateImgResourceResultEvent($defaultImageResource, $imageConfiguration);
         $event = $this->eventDispatcher->dispatch($event);
         $defaultImageResource = $event->getRenderedResult();
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -17,5 +17,7 @@ services:
     autowire: false
   PrototypeIntegration\PrototypeIntegration\Processor\Event\PictureProcessorRenderedEvent:
     autowire: false
+  PrototypeIntegration\PrototypeIntegration\Processor\Event\ImageProcessorManipulateImgResourceResultEvent:
+    autowire: false
   PrototypeIntegration\PrototypeIntegration\View\Event\ExtbaseViewAdapterVariablesConvertedEvent:
     autowire: false


### PR DESCRIPTION
## The feature:

With this new event listener in ImageProcessor class is it possible to manipulate the image resource array. The event runs direcly after the content object renderer return the image resource array.

## What is possible with the even:

The extension [EXT:webp](https://github.com/plan2net/webp), for example, can be used in a project. The generated image (e.g. png or jpeg) can now be exchanged with the generated webp image using the listener.

## Listener example:

```
    public function useWebpResource(ImageProcessorManipulateImgResourceResultEvent $event)
    {
        $imageResourceData = $event->getRenderedResult();
        $imageConfiguration = $event->getImageConfiguration();

        if (ExtensionManagementUtility::isLoaded('webp')
            && (isset($imageConfiguration['useWebp']) && $imageConfiguration['useWebp'])
        ) {
            $this->getImageResourceWithWebp($imageResourceData);
        }

        $event->setRenderedResult($imageResourceData);
    }

    protected function getImageResourceWithWebp(array &$imageResourceData): void
    {
        $renderedImageConfiguration = $imageResourceData['processedFile']->getProcessingConfiguration();

        $processedWebpFile = $this->processedFileRepository->findOneByOriginalFileAndTaskTypeAndConfiguration(
            $imageResourceData['processedFile']->getOriginalFile(),
            $imageResourceData['processedFile']->getTaskIdentifier(),
            $renderedImageConfiguration + ['webp' => true]
        );

        if ($processedWebpFile instanceof ProcessedFile && !empty($processedWebpFile->getIdentifier())) {
            $imageResourceData[3] = $processedWebpFile->getPublicUrl();
        }
    }
```
For the image configuration in TypoScript we can use the parameter `useWebp` to enable or disable the usage of webp images in different content elements and in image variants. This makes sense when it comes to high-resolution images that should be compressed as little as possible.