### PR TITLE
[BUGFIX] Fix mixup of content object states with nested PTI objects

### DIFF
--- a/Classes/ContentObject/PtiContentObject.php
+++ b/Classes/ContentObject/PtiContentObject.php
@@ -30,7 +30,6 @@ class PtiContentObject extends AbstractContentObject
 
         $this->typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
         $this->processorRunner = GeneralUtility::makeInstance(ProcessorRunner::class);
-        $this->processorRunner->injectContentObjectRenderer($this->cObj);
 
         $viewResolverClass = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['pti']['view']['viewResolver'];
         $this->viewResolver = GeneralUtility::makeInstance($viewResolverClass);
@@ -48,7 +47,7 @@ class PtiContentObject extends AbstractContentObject
             $this->templateName = $this->conf['templateName'];
         }
 
-        $data = $this->processorRunner->processData($this->cObj->data, $this->conf, $this->cObj->getCurrentTable());
+        $data = $this->processorRunner->processData($this->cObj, $this->conf, $this->cObj->getCurrentTable());
         $templateName = $this->getTemplateName();
 
         $view = $this->viewResolver->getViewForContentObject($data ?: [], $templateName);

--- a/Classes/DataProcessing/ProcessorRunner.php
+++ b/Classes/DataProcessing/ProcessorRunner.php
@@ -64,7 +64,6 @@ class ProcessorRunner
         string $className,
         array $configuration,
         ContentObjectRenderer $contentObjectRenderer,
-        string $table
     ): ?array {
         // Instantiate class
         $dataProcessor = GeneralUtility::makeInstance($className);

--- a/Classes/DataProcessing/ProcessorRunner.php
+++ b/Classes/DataProcessing/ProcessorRunner.php
@@ -12,8 +12,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 class ProcessorRunner
 {
-    protected ContentObjectRenderer $contentObjectRenderer;
-
     protected EventDispatcher $eventDispatcher;
 
     public function __construct(EventDispatcher $eventDispatcher)
@@ -21,13 +19,9 @@ class ProcessorRunner
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function injectContentObjectRenderer(ContentObjectRenderer $contentObjectRenderer)
+    public function processData(ContentObjectRenderer $contentObjectRenderer, array $conf, ?string $table): ?array
     {
-        $this->contentObjectRenderer = $contentObjectRenderer;
-    }
-
-    public function processData(array $data, array $conf, ?string $table): ?array
-    {
+        $data = $contentObjectRenderer->data;
         foreach ($conf['dataProcessors'] ?: [] as $dataProcessorConfiguration) {
             // Get classname
             $dataProcessorClassName = null;
@@ -43,14 +37,19 @@ class ProcessorRunner
                 throw new \RuntimeException('Missing className for dataProcessor', 1521297809618);
             }
 
-            $data = $this->runDataProcessor($dataProcessorClassName, $dataProcessorConfiguration, $data, $table);
+            $data = $this->runDataProcessor(
+                $dataProcessorClassName,
+                $dataProcessorConfiguration,
+                $contentObjectRenderer,
+                $table
+            );
             if (is_null($data)) {
                 return null;
             }
         }
 
-        if ($this->contentObjectRenderer->getCurrentTable() == 'tt_content') {
-            $uid = $this->contentObjectRenderer->data['_LOCALIZED_UID'] ?? $this->contentObjectRenderer->data['uid'] ?? null;
+        if ($contentObjectRenderer->getCurrentTable() == 'tt_content') {
+            $uid = $contentObjectRenderer->data['_LOCALIZED_UID'] ?? $contentObjectRenderer->data['uid'] ?? null;
             if (isset($uid)) {
                 $data['uid'] = $uid;
             }
@@ -61,8 +60,12 @@ class ProcessorRunner
         return $data;
     }
 
-    protected function runDataProcessor(string $className, array $configuration, array $data, string $table): ?array
-    {
+    protected function runDataProcessor(
+        string $className,
+        array $configuration,
+        ContentObjectRenderer $contentObjectRenderer,
+        string $table
+    ): ?array {
         // Instantiate class
         $dataProcessor = GeneralUtility::makeInstance($className);
 
@@ -74,14 +77,10 @@ class ProcessorRunner
         }
 
         if (method_exists($dataProcessor, 'injectContentObjectRenderer')) {
-            if (! isset($this->contentObjectRenderer)) {
-                $this->contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-                $this->contentObjectRenderer->start($data, $table);
-            }
-            $dataProcessor->injectContentObjectRenderer($this->contentObjectRenderer);
+            $dataProcessor->injectContentObjectRenderer($contentObjectRenderer);
         }
 
-        $data = $dataProcessor->process($data, $configuration);
+        $data = $dataProcessor->process($contentObjectRenderer->data, $configuration);
         return $data;
     }
 }

--- a/Classes/Processor/CompoundProcessor.php
+++ b/Classes/Processor/CompoundProcessor.php
@@ -135,8 +135,7 @@ class CompoundProcessor implements PtiDataProcessor
 
         /** @var ProcessorRunner $processorRunner */
         $processorRunner = GeneralUtility::makeInstance(ProcessorRunner::class);
-        $processorRunner->injectContentObjectRenderer($contentObjectRenderer);
-        $processedData = $processorRunner->processData($record, $plainConf, $table);
+        $processedData = $processorRunner->processData($contentObjectRenderer, $plainConf, $table);
         if (!isset($processedData['_templateName']) && isset($conf['templateName'])) {
             $processedData['_templateName'] = $conf['templateName'];
         }


### PR DESCRIPTION
The processor runner is declared as a service, so it will only be
instantiated once. This caused issues with multiple nested calls to the
same processor runners which kept overriding their internal content
object renderer state.

Keep the content object renderer on the call stack to isolate it in the
multiple calls scenario.