### PR TITLE
[TASK] Image processing: Allow string value to render images

### DIFF
--- a/Classes/Processor/ImageProcessor.php
+++ b/Classes/Processor/ImageProcessor.php
@@ -25,7 +25,10 @@ class ImageProcessor
         $this->tsfe = $GLOBALS['TSFE'];
     }
 
-    public function renderImage(FileInterface $file, array $conf = []): array
+    /**
+     * @param string|FileInterface $file
+     */
+    public function renderImage($file, array $conf = []): array
     {
         $defaultImageResource = $this->contentObject->getImgResource($file, $conf);
         if (is_null($defaultImageResource) || !isset($defaultImageResource[3])) {
@@ -53,11 +56,9 @@ class ImageProcessor
     }
 
     /**
-     * @param \TYPO3\CMS\Core\Resource\FileInterface $file
-     * @param array $configuration
-     * @return string
+     * @param string|FileInterface $file
      */
-    protected function renderRetinaImage(FileInterface $file, array $configuration): string
+    protected function renderRetinaImage($file, array $configuration): string
     {
         $retinaConfiguration = $this->getImageConfigurationForRetina($configuration);
         $image = $this->contentObject->getImgResource($file, $retinaConfiguration);


### PR DESCRIPTION
The `imgResource` function of TYPO3 can handle string values for images, therefore this data type should also be allowed. It thus enables the transfer of static images such as EXT:my_extension/Resources/Public/Images/MyImage.jpg