### PR TITLE
[FEATURE] Add new event to change or manipulate file metadata 

### DIFF
--- a/Classes/Processor/Event/FileMetadataProcessorEvent.php
+++ b/Classes/Processor/Event/FileMetadataProcessorEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrototypeIntegration\PrototypeIntegration\Processor\Event;
+
+use TYPO3\CMS\Core\Resource\FileInterface;
+
+class FileMetadataProcessorEvent
+{
+    public function __construct(
+        protected FileInterface $file,
+        protected array $metaData,
+    ) {
+    }
+
+    public function getFile(): FileInterface
+    {
+        return $this->file;
+    }
+
+    public function getMetaData(): array
+    {
+        return $this->metaData;
+    }
+
+    public function setMetaData(array $metaData): void
+    {
+        $this->metaData = $metaData;
+    }
+}

--- a/Classes/Processor/FileMetadataProcessor.php
+++ b/Classes/Processor/FileMetadataProcessor.php
@@ -13,6 +13,7 @@ class FileMetadataProcessor
         $properties = [
             'title' => 'title',
             'description' => 'description',
+            'caption' => 'caption',
             'copyright' => 'copyright',
             'link' => 'link',
             'alternative' => 'alternative',
@@ -29,6 +30,10 @@ class FileMetadataProcessor
                     $metaData[$key] = $value;
                 }
             }
+        }
+
+        if (isset($metaData['caption']) && !isset($metaData['description'])) {
+            $metaData['description'] = $metaData['caption'];
         }
 
         return $metaData;

--- a/Classes/Processor/FileMetadataProcessor.php
+++ b/Classes/Processor/FileMetadataProcessor.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace PrototypeIntegration\PrototypeIntegration\Processor;
 
+use PrototypeIntegration\PrototypeIntegration\Processor\Event\FileMetadataProcessorEvent;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Resource\FileInterface;
 
 class FileMetadataProcessor
 {
+    public function __construct(
+        protected EventDispatcher $eventDispatcher,
+    ) {
+    }
+
     public function processFile(FileInterface $file): array
     {
         $properties = [
             'title' => 'title',
             'description' => 'description',
-            'caption' => 'caption',
             'copyright' => 'copyright',
             'link' => 'link',
             'alternative' => 'alternative',
@@ -32,9 +38,8 @@ class FileMetadataProcessor
             }
         }
 
-        if (isset($metaData['caption']) && !isset($metaData['description'])) {
-            $metaData['description'] = $metaData['caption'];
-        }
+        $event = new FileMetadataProcessorEvent($file, $metaData);
+        $metaData = $this->eventDispatcher->dispatch($event)->getMetaData();
 
         return $metaData;
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -24,6 +24,8 @@ services:
     autowire: false
   PrototypeIntegration\PrototypeIntegration\Processor\Event\PictureProcessorRenderedEvent:
     autowire: false
+  PrototypeIntegration\PrototypeIntegration\Processor\Event\FileMetadataProcessorEvent:
+    autowire: false
   PrototypeIntegration\PrototypeIntegration\View\Event\ExtbaseViewAdapterVariablesConvertedEvent:
     autowire: false
 


### PR DESCRIPTION
## What does it do

With this new event, it is now possible to modify file metadata or add additional metadata.

## Why is it needed?

In some cases, TYPO3 extensions may extend the metadata, which should then also be included in PTI’s metadata array. However, since PTI is not aware of any additional metadata, this event provides the opportunity to respond to it.

## How to use the event

To use the event, create an EventListener in your Sitepackage; see the example below

### Example EventListener

```
<?php

declare(strict_types=1);

namespace YourNamespace\YourSitePackage\EventListener\Pti;

use PrototypeIntegration\PrototypeIntegration\Processor\Event\FileMetadataProcessorEvent;
use TYPO3\CMS\Core\Resource\FileInterface;

final readonly class FileMetaDataProcessorEventListener
{
    public function __invoke(
        FileMetadataProcessorEvent $event,
    ): void {
        $metaData = $event->getMetaData();
        $additionalProperties = [
            'my-special-property',
            'another-property',
        ];

        foreach ($additionalProperties as $property) {
            $metaData[$property] = $this->getMetaDataProperty($event->getFile(), $property);
            }
        }

        $event->setMetaData($metaData);
    }

    private function getMetaDataProperty(FileInterface $file, string $property): string
    {
        if ($file->hasProperty($property)) {
            return $file->getProperty($property);
        }

        return '';
    }
}
```

### Extend the Service.yaml

```
  YourNamespace\YourSitePackage\EventListener\Pti\FileMetaDataProcessorEventListener:
    tags:
      - name: event.listener
        identifier: 'addOrChangeFileMetaData'
        event: PrototypeIntegration\PrototypeIntegration\Processor\Event\FileMetadataProcessorEvent
```