### PR TITLE
[FEAT] Allow stdWrap for templateName

### DIFF
--- a/Classes/ContentObject/PtiContentObject.php
+++ b/Classes/ContentObject/PtiContentObject.php
@@ -31,7 +31,7 @@ class PtiContentObject extends AbstractContentObject
         $this->conf = $this->typoScriptService->convertTypoScriptArrayToPlainArray($conf);
 
         if (isset($this->conf['templateName'])) {
-            $this->templateName = $this->conf['templateName'];
+            $this->templateName = $this->cObj->stdWrapValue('templateName', $conf ?? []);
         }
 
         $data = $this->processorRunner->processData($this->cObj, $this->conf, $this->cObj->getCurrentTable());


### PR DESCRIPTION
Allow `stdWrap` for the `templateName` of a PTI content object. With this code change dynamic template selection based on e.g. `backend_layout` is possible

```
page = PAGE
page.10 = PTI
page.10 {
  templateName.stdWrap.cObject = CASE
  templateName.stdWrap.cObject {
    key.data = pagelayout

    pagets__myextension_userprofile = TEXT
    pagets__myextension_userprofile.value = @pages/UserProfile.twig

    default = TEXT
    default.value = @pages/Standard.twig
  }
}
```